### PR TITLE
Bundle content scripts as IIFEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,19 +53,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # The e2e Laravel app depends on the private inertia-laravel fork that carries
-      # the devtools server. composer resolves it through a path repository pointing
-      # at a sibling checkout of this repo, so clone it there before installing.
-      # Remove this step once the fork is merged into public inertia-laravel and the
-      # composer `repositories` override is dropped.
-      - name: Checkout inertia-laravel devtools fork
-        run: |
-          git clone --depth 1 \
-            "https://x-access-token:${TOKEN}@github.com/inertiajs/inertia-laravel-devtools.git" \
-            "${{ github.workspace }}/../inertia-laravel-devtools"
-        env:
-          TOKEN: ${{ secrets.INERTIA_LARAVEL_DEVTOOLS_TOKEN }}
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/tests/e2e/app/composer.json
+++ b/tests/e2e/app/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "inertiajs/inertia-laravel": "*",
+        "inertiajs/inertia-laravel": "^3.2.1",
         "laravel/framework": "^13.8"
     },
     "autoload": {
@@ -34,12 +34,5 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true,
-    "repositories": [
-        {
-            "name": "inertia-devtools",
-            "type": "path",
-            "url": "../../../../inertia-laravel-devtools"
-        }
-    ]
+    "prefer-stable": true
 }

--- a/tests/e2e/app/composer.lock
+++ b/tests/e2e/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bfb231f8a876872c73b9959acfe990e0",
+    "content-hash": "cd8bf7f9a95e77fdaf74c5490c7eca6a",
     "packages": [
         {
             "name": "brick/math",
@@ -1059,15 +1059,21 @@
         },
         {
             "name": "inertiajs/inertia-laravel",
-            "version": "dev-master",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/inertiajs/inertia-laravel.git",
+                "reference": "e6ad31fbafb3c8d1c269c93ab12da3712c077744"
+            },
             "dist": {
-                "type": "path",
-                "url": "../../../../inertia-laravel-devtools",
-                "reference": "d4d144052d7d2f05679c7a25f78b24b37686b803"
+                "type": "zip",
+                "url": "https://api.github.com/repos/inertiajs/inertia-laravel/zipball/e6ad31fbafb3c8d1c269c93ab12da3712c077744",
+                "reference": "e6ad31fbafb3c8d1c269c93ab12da3712c077744",
+                "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "laravel/framework": "^11.0|^12.0|^13.0",
+                "laravel/framework": "^11.35|^12.0|^13.0",
                 "php": "^8.2.0",
                 "symfony/console": "^7.0|^8.0"
             },
@@ -1075,13 +1081,12 @@
                 "laravel/boost": "<2.2.0"
             },
             "require-dev": {
-                "guzzlehttp/guzzle": "^7.2",
+                "guzzlehttp/guzzle": "^7.15.2|^8.0",
                 "larastan/larastan": "^3.0",
                 "laravel/pint": "^1.16",
                 "mockery/mockery": "^1.3.3",
                 "orchestra/testbench": "^9.2|^10.0|^11.0",
-                "phpunit/phpunit": "^11.5|^12.0",
-                "roave/security-advisories": "dev-master"
+                "phpunit/phpunit": "^11.5|^12.0"
             },
             "suggest": {
                 "ext-pcntl": "Recommended when running the Inertia SSR server via the `inertia:start-ssr` artisan command."
@@ -1095,29 +1100,14 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Inertia\\": "src"
-                },
                 "files": [
                     "./helpers.php"
-                ]
-            },
-            "autoload-dev": {
+                ],
                 "psr-4": {
-                    "Inertia\\Tests\\": "tests/"
+                    "Inertia\\": "src"
                 }
             },
-            "scripts": {
-                "test": [
-                    "phpunit"
-                ],
-                "lint": [
-                    "pint"
-                ],
-                "analyze": [
-                    "phpstan analyze --memory-limit=512M"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -1133,9 +1123,11 @@
                 "inertia",
                 "laravel"
             ],
-            "transport-options": {
-                "relative": true
-            }
+            "support": {
+                "issues": "https://github.com/inertiajs/inertia-laravel/issues",
+                "source": "https://github.com/inertiajs/inertia-laravel/tree/v3.2.1"
+            },
+            "time": "2026-07-29T09:10:23+00:00"
         },
         {
             "name": "laravel/framework",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ const distDir = resolve(__dirname, 'dist')
 const STATIC_ASSETS = ['manifest.json', 'icons']
 
 // Scripts the manifest loads by a fixed name, so they stay unhashed at the build root.
-const ROOT_ENTRIES = ['content-script', 'page-world']
+const CONTENT_SCRIPTS = ['content-script', 'page-world']
 
 /**
  * Copy the manifest and icons into the build directory once Vite finishes.
@@ -74,10 +74,58 @@ function buildServiceWorker(mode: string): PluginOption {
   }
 }
 
+/**
+ * Bundle each content script as a self-contained IIFE.
+ *
+ * The manifest loads these as classic scripts, so top-level bindings leak into the world they run
+ * in. `page-world` runs in the MAIN world, where a minified `var e` is enough to make a page's own
+ * `let e` fail to parse, taking down that script and everything downstream of it.
+ */
+function buildContentScripts(mode: string): PluginOption {
+  return {
+    name: 'inertia-devtools-content-scripts',
+    apply: 'build',
+    async closeBundle() {
+      for (const entry of CONTENT_SCRIPTS) {
+        await viteBuild({
+          configFile: false,
+          root: srcDir,
+          publicDir: false,
+          mode,
+          build: {
+            outDir: distDir,
+            emptyOutDir: false,
+            minify: mode === 'production',
+            sourcemap: mode !== 'production',
+            lib: {
+              entry: resolve(srcDir, `${entry}.ts`),
+              formats: ['iife'],
+              name: 'inertiaDevtools',
+              fileName: () => `${entry}.js`,
+            },
+            // Disable code splitting: a content script cannot follow an ES module chunk import.
+            rollupOptions: { output: { codeSplitting: false } },
+          },
+        })
+
+        // Guard the property that actually matters, since nothing else in the build enforces it.
+        const code = readFileSync(resolve(distDir, `${entry}.js`), 'utf8').trim()
+
+        if (!code.startsWith('(')) {
+          throw new Error(
+            `Content script (${entry}.js) does not open as an IIFE, so its top-level declarations ` +
+              'leak into the world it runs in. It must stay wrapped.',
+          )
+        }
+      }
+    },
+  }
+}
+
 export default defineConfig(({ mode }) => ({
   root: srcDir,
   publicDir: false,
-  plugins: [vue(), tailwindcss(), buildServiceWorker(mode), copyStaticAssets()],
+  plugins: [vue(), tailwindcss(), buildServiceWorker(mode), buildContentScripts(mode), copyStaticAssets()],
   build: {
     outDir: distDir,
     emptyOutDir: true,
@@ -87,8 +135,6 @@ export default defineConfig(({ mode }) => ({
     modulePreload: false,
     rollupOptions: {
       input: {
-        'content-script': resolve(srcDir, 'content-script.ts'),
-        'page-world': resolve(srcDir, 'page-world.ts'),
         devtools: resolve(srcDir, 'devtools/devtools.html'),
         panel: resolve(srcDir, 'panel/panel.html'),
         popup: resolve(srcDir, 'popup/popup.html'),
@@ -97,7 +143,7 @@ export default defineConfig(({ mode }) => ({
         // Keep constants and guards in one stable chunk shared by the extension pages. The
         // content scripts import nothing and the worker is built separately, so neither uses it.
         manualChunks: (id) => (/\/src\/(constants|guards)\.ts$/.test(id) ? 'shared' : undefined),
-        entryFileNames: (chunk) => (ROOT_ENTRIES.includes(chunk.name) ? '[name].js' : 'assets/[name].js'),
+        entryFileNames: 'assets/[name].js',
         chunkFileNames: 'assets/[name].js',
         assetFileNames: 'assets/[name][extname]',
       },


### PR DESCRIPTION
Vite emits the multi-entry build-in ES module format, but the manifest loads `content-script.js` and `page-world.js` as classic scripts. Top-level bindings in a classic script land in the scope it runs in, so every minified name in the bundle became a global (`var e`, `var t`, `var n`, etc.). For `page-world`, which runs in the MAIN world, that scope is the inspected page's own.

Any page whose scripts declare a colliding top-level `let` then fails to parse, not merely at runtime. On reddit.com, our global `e` broke their first inline script with "Identifier 'e' has already been declared", which took out the helper the rest of their inline scripts call, and infinite scroll stopped loading posts entirely.

Content scripts now build as separate single-entry IIFE bundles, the same way the service worker is already built, so nothing escapes into the page. The build fails if either bundle stops opening as an IIFE.