### PR TITLE
Support Chrome private browsing

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,7 @@
     }
   },
   "minimum_chrome_version": "116",
+  "incognito": "split",
   "permissions": ["storage", "declarativeNetRequest", "webRequest", "tabs"],
   "host_permissions": ["http://*/*", "https://*/*"],
   "background": {


### PR DESCRIPTION
Without an incognito mode in the manifest the extension ran in Chrome's default spanning mode, where a single worker in the regular profile never receives webRequest events from a private window, so no visits were recorded. Only full page loads occasionally showed up, since those are ingested from the DOM id tag instead of a response header.

Declaring split mode gives each private window its own worker, so requests from that window reach a worker that is allowed to see them.

Fixes #14.